### PR TITLE
fix: various button sizes and focus styles

### DIFF
--- a/src/components/Accordion/AccordionButton.tsx
+++ b/src/components/Accordion/AccordionButton.tsx
@@ -40,7 +40,7 @@ const AccordionButton = ({
         ? undefined
         : {
             sx: {
-              '&:focus, &:hover': {
+              '&:focus-visible, &:hover': {
                 'svg:last-child': { color: 'currentcolor' },
               },
             },

--- a/src/components/Accordion/theme.ts
+++ b/src/components/Accordion/theme.ts
@@ -10,19 +10,19 @@ const $chakraSpaceSm = cssVar('chakra-space-sm');
 const variant = {
   sidebar: {
     button: {
-      _hover: {
-        color: 'orange-0',
-      },
-
-      _focus: {
-        color: 'orange-0',
-      },
-
       border: 'none',
       borderRadius: 0,
       fontSize: 'sm',
       paddingX: 'md',
       paddingY: 0,
+
+      _focusVisible: {
+        color: 'orange-0',
+      },
+
+      _hover: {
+        color: 'orange-0',
+      },
     },
 
     container: {
@@ -47,14 +47,6 @@ const variant = {
 export default defineMultiStyleConfig({
   baseStyle: definePartsStyle({
     button: {
-      _focus: {
-        background: 'blue-10%',
-      },
-
-      _hover: {
-        background: 'blue-10%',
-      },
-
       background: 'white-0',
       borderColor: 'gray-1',
       borderRadius: 'md',
@@ -69,6 +61,14 @@ export default defineMultiStyleConfig({
       transitionDuration: 'default',
       transitionProperty: 'background, border-radius, color',
       transitionTimingFunction: 'default',
+
+      _focusVisible: {
+        background: 'blue-10%',
+      },
+
+      _hover: {
+        background: 'blue-10%',
+      },
     },
 
     container: {
@@ -111,19 +111,19 @@ export default defineMultiStyleConfig({
       ...variant.sidebar,
       button: {
         ...variant.sidebar.button,
+        background: 'navy-0',
+        color: 'gray-4',
+        textTransform: 'uppercase',
+
+        _focusVisible: {
+          ...variant.sidebar.button._focusVisible,
+          background: 'navy-1',
+        },
+
         _hover: {
           ...variant.sidebar.button._hover,
           background: 'navy-1',
         },
-
-        _focus: {
-          ...variant.sidebar.button._focus,
-          background: 'navy-1',
-        },
-
-        background: 'navy-0',
-        color: 'gray-4',
-        textTransform: 'uppercase',
       },
 
       icon: {
@@ -141,20 +141,20 @@ export default defineMultiStyleConfig({
       ...variant.sidebar,
       button: {
         ...variant.sidebar.button,
-        _hover: {
-          ...variant.sidebar.button._hover,
-          background: 'navy-2',
-        },
-
-        _focus: {
-          ...variant.sidebar.button._focus,
-          background: 'navy-2',
-        },
-
         background: 'navy-1',
         color: 'white-0',
         fontWeight: 'normal',
         gap: 'xs',
+
+        _focusVisible: {
+          ...variant.sidebar.button._focusVisible,
+          background: 'navy-2',
+        },
+
+        _hover: {
+          ...variant.sidebar.button._hover,
+          background: 'navy-2',
+        },
       },
 
       icon: {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,12 +1,30 @@
 import { Button as ChakraButton, forwardRef } from '@chakra-ui/react';
 import type { ButtonProps as ChakraButtonProps } from '@chakra-ui/react';
-import React from 'react';
+import React, { cloneElement } from 'react';
 
 export interface ButtonProps extends ChakraButtonProps {}
 
 const Button = forwardRef<ButtonProps, 'button'>(
-  ({ children, ...rest }, ref) => (
-    <ChakraButton ref={ref} iconSpacing={children ? 'xs' : 0} {...rest}>
+  ({ children, leftIcon, rightIcon, ...rest }, ref) => (
+    <ChakraButton
+      ref={ref}
+      iconSpacing={children ? 'xs' : 0}
+      {...(leftIcon
+        ? {
+            leftIcon: leftIcon.props?.size
+              ? leftIcon
+              : cloneElement(leftIcon, { size: 'sm' }),
+          }
+        : undefined)}
+      {...(rightIcon
+        ? {
+            rightIcon: rightIcon.props?.size
+              ? rightIcon
+              : cloneElement(rightIcon, { size: 'sm' }),
+          }
+        : undefined)}
+      {...rest}
+    >
       {children}
     </ChakraButton>
   )

--- a/src/components/Button/theme.ts
+++ b/src/components/Button/theme.ts
@@ -63,21 +63,21 @@ export default defineStyleConfig({
 
   sizes: {
     xs: {
-      fontSize: 'md',
+      fontSize: 'sm',
       height: 'auto',
       minWidth: 0,
       padding: 0,
     },
 
     sm: {
-      fontSize: 'md',
+      fontSize: 'sm',
       height: 34,
       minWidth: 0,
       paddingX: 'md',
     },
 
     md: {
-      fontSize: 'md',
+      fontSize: 'sm',
       height: 40,
       minWidth: 0,
       paddingX: 'md',

--- a/src/components/Sidebar/SidebarButton.tsx
+++ b/src/components/Sidebar/SidebarButton.tsx
@@ -28,26 +28,26 @@ const SidebarButton = ({
     width="full"
     {...[
       {
-        _focus: { background: 'navy-1', color: 'orange-0' },
-        _hover: { background: 'navy-1', color: 'orange-0' },
         background: 'navy-0',
         height: 34,
         fontSize: 'md',
+        _focusVisible: { background: 'navy-1', color: 'orange-0' },
+        _hover: { background: 'navy-1', color: 'orange-0' },
       },
       {
-        _focus: { background: 'navy-2', color: 'orange-0' },
-        _hover: { background: 'navy-2', color: 'orange-0' },
         background: 'navy-1',
         height: 44,
         fontSize: 'sm',
+        _focusVisible: { background: 'navy-2', color: 'orange-0' },
+        _hover: { background: 'navy-2', color: 'orange-0' },
       },
       {
-        _focus: { color: 'orange-0' },
-        _hover: { color: 'orange-0' },
         background: 'navy-2',
         paddingLeft: 'xl',
         height: 44,
         fontSize: 'sm',
+        _focusVisible: { color: 'orange-0' },
+        _hover: { color: 'orange-0' },
       },
     ][Number(level)]}
     {...rest}


### PR DESCRIPTION
This PR fixes various button (namely `AccordionButton`, `Button` and `SidebarButton`) text and icon sizes as well as focus styles (replace `:focus` with `:focus-visible`) to be equivalent to those designed in Figma.