### PR TITLE
fix: menu list z-index

### DIFF
--- a/src/components/Menu/theme.ts
+++ b/src/components/Menu/theme.ts
@@ -53,6 +53,7 @@ export default defineMultiStyleConfig({
       paddingX: 0,
       paddingY: 'sm',
       width: 'auto',
+      zIndex: 1,
     },
   }),
 


### PR DESCRIPTION
This PR fixes missing `MenuList` `z-index` property, which caused rendering some elements (e.g. `Button`) above the menu.