### PR TITLE
fix: keep button size constant when it is a flex child

### DIFF
--- a/src/components/Button/theme.ts
+++ b/src/components/Button/theme.ts
@@ -44,6 +44,7 @@ const variant = {
 export default defineStyleConfig({
   baseStyle: {
     borderRadius: 'md',
+    flex: 'none',
     fontWeight: 'normal',
     lineHeight: 'normal',
     justifyContent: 'center',


### PR DESCRIPTION
This PR sets `flex: none;` property on `Button` component, which keeps its size constant when it is a flex child.