### PR TITLE
fix: allow overriding default parameters in dynamic toast calls

### DIFF
--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -2,7 +2,7 @@ import LinkTo from '@storybook/addon-links/react';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
 import React, { useCallback } from 'react';
 
-import { Button, Code, Flex, Link, Text, useToast } from '../..';
+import { Button, Code, Divider, Flex, Link, Text, useToast } from '../..';
 import type { UseToastOptions } from '../..';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -24,13 +24,30 @@ const Template: ComponentStory<typeof Toast> = (args: UseToastOptions) => {
     <Flex align="flex-start" direction="column" gap="sm">
       <Text>
         As opposed to standard JSX components, <Code>Toast</Code> is rendered by{' '}
-        <Code>useToast</Code> hook. For rendering standard JSX components make
-        sure to check out{' '}
+        <Code>toast</Code> function returned from <Code>useToast</Code> hook.
+        For rendering standard JSX components make sure to check out{' '}
         <Link as={LinkTo} kind="Components/Alert" story="Basic">
           Alert
         </Link>
         .
       </Text>
+      <Text>
+        All parameters passed to <Code>useToast</Code> hook, can also be passed
+        to its returned <Code>toast</Code> function. This is especially useful
+        in case of dynamic parameters. For example, this call:
+      </Text>
+      <Text>
+        <Code whiteSpace="pre-wrap">
+          {"const toast = useToast({ title: 'Title' });\ntoast();"}
+        </Code>
+      </Text>
+      <Text>Is an equivalent of:</Text>
+      <Text>
+        <Code whiteSpace="pre-wrap">
+          {"const toast = useToast();\ntoast({ title: 'Title' });"}
+        </Code>
+      </Text>
+      <Divider marginY="sm" />
       <Text>
         <Code whiteSpace="pre-wrap">
           const toast = useToast({`${JSON.stringify(args, null, 2)}`});

--- a/src/components/Toast/useToast.tsx
+++ b/src/components/Toast/useToast.tsx
@@ -33,16 +33,25 @@ const useToast = ({
     description,
     isClosable,
     position,
-    render: ({ onClose }) => (
-      <Alert status={status}>
-        <AlertIcon>{icon}</AlertIcon>
-        <AlertBody hasCloseButton={isClosable}>
-          {title ? <AlertTitle>{title}</AlertTitle> : null}
-          {description ? (
-            <AlertDescription>{description}</AlertDescription>
+    render: ({ onClose, ...props }) => (
+      <Alert status={props?.status ?? status}>
+        <AlertIcon>{props?.icon ?? icon}</AlertIcon>
+
+        <AlertBody hasCloseButton={props?.isClosable ?? isClosable}>
+          {props?.title ?? title ? (
+            <AlertTitle>{props?.title ?? title}</AlertTitle>
+          ) : null}
+
+          {props?.description ?? description ? (
+            <AlertDescription>
+              {props?.description ?? description}
+            </AlertDescription>
           ) : null}
         </AlertBody>
-        {isClosable ? <AlertCloseButton onClick={onClose} /> : null}
+
+        {props?.isClosable ?? isClosable ? (
+          <AlertCloseButton onClick={onClose} />
+        ) : null}
       </Alert>
     ),
     status,

--- a/src/components/Toast/useToast.tsx
+++ b/src/components/Toast/useToast.tsx
@@ -12,17 +12,19 @@ import {
 
 export interface UseToastOptions extends ChakraUseToastOptions {}
 
-const useToast = ({
-  containerStyle,
-  description,
-  icon,
-  isClosable = true,
-  position = 'top-right',
-  status = 'info',
-  title,
-  ...rest
-}: UseToastOptions) =>
-  chakraUseToast({
+const useToast = (options?: UseToastOptions) => {
+  const {
+    containerStyle,
+    description,
+    icon,
+    isClosable = true,
+    position = 'top-right',
+    status = 'info',
+    title,
+    ...rest
+  } = options ?? {};
+
+  return chakraUseToast({
     containerStyle: {
       marginBottom: 0,
       marginTop: 'sm',
@@ -58,5 +60,6 @@ const useToast = ({
     title,
     ...rest,
   });
+};
 
 export default useToast;


### PR DESCRIPTION
This PR fixes dynamic `toast(...)` calls, which can now override default parameters defined in initial `useToast` call:

![image](https://user-images.githubusercontent.com/117445994/233655242-5b99e9e3-3f59-4056-a32b-6c593e28883f.png)
