### PR TITLE
fix: table horizontal scroll in nautobot grid

### DIFF
--- a/src/components/NautobotGrid/NautobotGrid.tsx
+++ b/src/components/NautobotGrid/NautobotGrid.tsx
@@ -129,11 +129,11 @@ const NautobotGrid = forwardRef<NautobotGridProps, 'div'>(
     const rowSpans = getCellsSpan(rows);
 
     const autoColumns = `minmax(${
-      (typeof columns === 'object' && columns?.minWidth) || 'min-content'
+      (typeof columns === 'object' && columns?.minWidth) || 'auto'
     }, ${(typeof columns === 'object' && columns?.maxWidth) || '1fr'})`;
 
     const autoRows = `minmax(${
-      (typeof rows === 'object' && rows?.minHeight) || 'min-content'
+      (typeof rows === 'object' && rows?.minHeight) || 'auto'
     }, ${(typeof rows === 'object' && rows?.maxHeight) || '1fr'})`;
 
     return (

--- a/src/components/Table/TableContainer.tsx
+++ b/src/components/Table/TableContainer.tsx
@@ -14,7 +14,7 @@ const TableContainer = forwardRef<TableContainerProps, 'div'>((props, ref) => (
     borderRadius="md"
     borderStyle="solid"
     borderWidth={1}
-    overflow="hidden"
+    overflow="auto"
     width="full"
     {...props}
   />


### PR DESCRIPTION
This PR fixes an issue when `Table` component was wider than browser viewport and was rendered as `NautobotGrid` descendant. In that case it would not respect `overflow: hidden` and/or `overflow: auto` property set on its container and would overflow to an unreachable part of the screen.

Explanation: tables with `min-content` keyword set on their (or their ancestor) width ignore `overflow: hidden` and/or `overflow: auto` property and are displayed in full size, even when it means outside of browser viewport.