### PR TITLE
feature: implement table sticky columns

### DIFF
--- a/src/components/Menu/theme.ts
+++ b/src/components/Menu/theme.ts
@@ -25,6 +25,7 @@ export default defineMultiStyleConfig({
 
     item: {
       color: 'black-0',
+      minWidth: 180,
       paddingX: 'md',
       paddingY: 'xs',
       textStyle: 'P2',
@@ -49,7 +50,6 @@ export default defineMultiStyleConfig({
       background: $menuBg.reference,
       borderRadius: 'sm',
       boxShadow: $menuShadow.reference,
-      minWidth: 180,
       paddingX: 0,
       paddingY: 'sm',
       width: 'auto',

--- a/src/components/Table/TableRenderer.tsx
+++ b/src/components/Table/TableRenderer.tsx
@@ -1,9 +1,11 @@
+import { Flex } from '@chakra-ui/react';
 import { flexRender } from '@tanstack/react-table';
 import type { useReactTable } from '@tanstack/react-table';
-import React from 'react';
+import React, { useRef } from 'react';
 
-import { Flex } from '../..';
 import { SortAscendingIcon } from '../../icons';
+
+import { getCellStickyProps, useTableScrollPosition } from './utils';
 
 import { Table, TableContainer, Tbody, Td, Th, Thead, Tr } from './';
 import type { TableContainerProps, TableProps } from './';
@@ -17,121 +19,143 @@ const TableRenderer = <Datum extends object>({
   containerProps,
   table,
   ...rest
-}: TableRendererProps<Datum>) => (
-  <TableContainer {...containerProps}>
-    <Table {...rest}>
-      {table.options.meta?.hideTableHeader ? null : (
-        <Thead>
-          {table.getHeaderGroups().map(({ headers, id }) => (
-            <Tr key={id}>
-              {headers.map(({ column, getContext, id: headerId }) => {
-                const optionalStyle = {
-                  ...(column.columnDef.meta?.minimumWidth
-                    ? { width: 0 }
-                    : undefined),
-                  ...(column.columnDef.meta?.noHeaderCellPaddings
-                    ? {
-                        _first: { padding: 0 },
-                        _last: { padding: 0 },
-                        padding: 0,
-                      }
-                    : undefined),
-                };
+}: TableRendererProps<Datum>) => {
+  const tableContainerRef = useRef<HTMLDivElement>(null);
 
-                return column.columnDef.meta?.disableSorting ? (
-                  <Th key={headerId} {...optionalStyle}>
-                    {flexRender(column.columnDef.header, getContext())}
-                  </Th>
-                ) : (
-                  <Th
-                    key={headerId}
-                    _hover={{ background: 'blue-10%' }}
-                    cursor="pointer"
-                    tabIndex={0}
-                    transitionDuration="default"
-                    transitionProperty="background"
-                    transitionTimingFunction="default"
-                    onClick={column.getToggleSortingHandler()}
-                    {...optionalStyle}
-                  >
-                    <Flex align="center" height="full" width="full">
+  const { isTableScrolledToTheLeft, isTableScrolledToTheRight } =
+    useTableScrollPosition(tableContainerRef);
+
+  return (
+    <TableContainer ref={tableContainerRef} {...containerProps}>
+      <Table {...rest}>
+        {table.options.meta?.hideTableHeader ? null : (
+          <Thead>
+            {table.getHeaderGroups().map(({ headers, id }) => (
+              <Tr key={id}>
+                {headers.map(({ column, getContext, id: headerId }) => {
+                  const optionalStyle = {
+                    ...(column.columnDef.meta?.minimumWidth
+                      ? { width: 0 }
+                      : undefined),
+                    ...(column.columnDef.meta?.noHeaderCellPaddings
+                      ? {
+                          _first: { padding: 0 },
+                          _last: { padding: 0 },
+                          padding: 0,
+                        }
+                      : undefined),
+                    ...getCellStickyProps(
+                      {
+                        columnId: column.id,
+                        isTableScrolledToTheLeft,
+                        isTableScrolledToTheRight,
+                        table,
+                      },
+                      { zIndex: 2 }
+                    ),
+                  };
+
+                  return column.columnDef.meta?.disableSorting ? (
+                    <Th key={headerId} {...optionalStyle}>
                       {flexRender(column.columnDef.header, getContext())}
-                      <SortAscendingIcon
-                        display="inline-block"
-                        flex="none"
-                        marginLeft="sm"
-                        sx={{
-                          '>': (() => {
-                            const isSorted = column.getIsSorted();
+                    </Th>
+                  ) : (
+                    <Th
+                      key={headerId}
+                      _hover={{ background: 'blue-10%' }}
+                      cursor="pointer"
+                      tabIndex={0}
+                      transitionDuration="default"
+                      transitionProperty="background"
+                      transitionTimingFunction="default"
+                      onClick={column.getToggleSortingHandler()}
+                      {...optionalStyle}
+                    >
+                      <Flex align="center" height="full" width="full">
+                        {flexRender(column.columnDef.header, getContext())}
+                        <SortAscendingIcon
+                          display="inline-block"
+                          flex="none"
+                          marginLeft="sm"
+                          sx={{
+                            '>': (() => {
+                              const isSorted = column.getIsSorted();
 
-                            if (isSorted === 'asc') {
-                              return {
-                                _first: { stroke: 'blue-1' },
-                                _last: { stroke: 'currentcolor' },
-                              };
-                            } else if (isSorted === 'desc') {
+                              if (isSorted === 'asc') {
+                                return {
+                                  _first: { stroke: 'blue-1' },
+                                  _last: { stroke: 'currentcolor' },
+                                };
+                              } else if (isSorted === 'desc') {
+                                return {
+                                  _first: { stroke: 'currentcolor' },
+                                  _last: { stroke: 'blue-1' },
+                                };
+                              }
                               return {
                                 _first: { stroke: 'currentcolor' },
-                                _last: { stroke: 'blue-1' },
+                                _last: { stroke: 'currentcolor' },
                               };
-                            }
-                            return {
-                              _first: { stroke: 'currentcolor' },
-                              _last: { stroke: 'currentcolor' },
-                            };
-                          })(),
-                        }}
-                        transitionDuration="default"
-                        transitionProperty="opacity, visibility"
-                        transitionTimingFunction="default"
-                        {...(column.getIsSorted()
-                          ? {
-                              'aria-label':
-                                column.getIsSorted() === 'asc'
-                                  ? 'Ascending'
-                                  : 'Descending',
-                              opacity: 1,
-                              visibility: 'visible',
-                            }
-                          : {
-                              'aria-hidden': true,
-                              opacity: 0,
-                              visibility: 'hidden',
-                            })}
-                      />
-                    </Flex>
-                  </Th>
-                );
-              })}
+                            })(),
+                          }}
+                          transitionDuration="default"
+                          transitionProperty="opacity, visibility"
+                          transitionTimingFunction="default"
+                          {...(column.getIsSorted()
+                            ? {
+                                'aria-label':
+                                  column.getIsSorted() === 'asc'
+                                    ? 'Ascending'
+                                    : 'Descending',
+                                opacity: 1,
+                                visibility: 'visible',
+                              }
+                            : {
+                                'aria-hidden': true,
+                                opacity: 0,
+                                visibility: 'hidden',
+                              })}
+                        />
+                      </Flex>
+                    </Th>
+                  );
+                })}
+              </Tr>
+            ))}
+          </Thead>
+        )}
+
+        <Tbody>
+          {table.getRowModel().rows.map(({ getVisibleCells, id }) => (
+            <Tr
+              key={id}
+              {...(table.options.meta?.disableRowHover
+                ? { _hover: {} }
+                : undefined)}
+            >
+              {getVisibleCells().map(({ column, getContext, id: cellId }) => (
+                <Td
+                  key={cellId}
+                  {...(column.columnDef.meta?.minimumWidth
+                    ? { width: 0 }
+                    : undefined)}
+                  {...getCellStickyProps({
+                    columnId: column.id,
+                    isTableScrolledToTheLeft,
+                    isTableScrolledToTheRight,
+                    table,
+                  })}
+                >
+                  {flexRender(column.columnDef.cell, getContext())}
+                </Td>
+              ))}
             </Tr>
           ))}
-        </Thead>
-      )}
-
-      <Tbody>
-        {table.getRowModel().rows.map(({ getVisibleCells, id }) => (
-          <Tr
-            key={id}
-            {...(table.options.meta?.disableRowHover
-              ? { _hover: {} }
-              : undefined)}
-          >
-            {getVisibleCells().map(({ column, getContext, id: cellId }) => (
-              <Td
-                key={cellId}
-                {...(column.columnDef.meta?.minimumWidth
-                  ? { width: 0 }
-                  : undefined)}
-              >
-                {flexRender(column.columnDef.cell, getContext())}
-              </Td>
-            ))}
-          </Tr>
-        ))}
-      </Tbody>
-    </Table>
-  </TableContainer>
-);
+        </Tbody>
+      </Table>
+    </TableContainer>
+  );
+};
 
 TableRenderer.displayName = 'TableRenderer';
 

--- a/src/components/Table/columnDef/getColumnDefActionMenu.tsx
+++ b/src/components/Table/columnDef/getColumnDefActionMenu.tsx
@@ -1,20 +1,18 @@
-import { calc, cssVar } from '@chakra-ui/react';
+import { calc } from '@chakra-ui/react';
 import type { CellContext, HeaderContext } from '@tanstack/react-table';
 import React from 'react';
 import type { ElementType } from 'react';
 
-import {
-  Button,
-  Checkbox,
-  Popover,
-  PopoverArrow,
-  PopoverBody,
-  PopoverContent,
-  PopoverTrigger,
-} from '../..';
 import { SettingsIcon } from '../../../icons';
-
-const $chakraSpace16 = cssVar('chakra-space-16');
+import { getCssVar } from '../../../utils';
+import Button from '../../Button';
+import {
+  Menu,
+  MenuButton,
+  MenuItemOption,
+  MenuList,
+  MenuOptionGroup,
+} from '../../Menu';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getColumnDefActionMenu = <Datum extends object, TValue = any>({
@@ -26,25 +24,42 @@ const getColumnDefActionMenu = <Datum extends object, TValue = any>({
     ActionMenu ? <ActionMenu cellContext={cellContext} /> : null,
 
   header: ({ table }: HeaderContext<Datum, TValue>) => (
-    <Popover placement="bottom-end">
-      <PopoverTrigger>
-        <Button
-          _active={{ background: 'blue-10%' }}
-          _focusVisible={{ background: 'blue-10%' }}
-          _hover={{ background: 'blue-10%' }}
-          borderRadius={0}
-          color="blue-1"
-          height="auto"
-          leftIcon={<SettingsIcon size="sm" />}
-          paddingLeft={8}
-          paddingRight={calc.subtract($chakraSpace16.reference, '1px')}
-          paddingY="11px"
-          variant="unstyled"
-        />
-      </PopoverTrigger>
-      <PopoverContent>
-        <PopoverArrow />
-        <PopoverBody>
+    <Menu closeOnSelect={false} placement="bottom-end">
+      <MenuButton
+        _active={{ background: 'blue-10%' }}
+        _focusVisible={{ background: 'blue-10%' }}
+        _hover={{ background: 'blue-10%' }}
+        as={Button}
+        borderRadius={0}
+        color="blue-1"
+        height="auto"
+        leftIcon={<SettingsIcon size="sm" />}
+        paddingLeft={8}
+        paddingRight={calc.subtract(getCssVar('space.16').reference, '1px')}
+        paddingY={calc.subtract(getCssVar('space.12').reference, '1px')}
+        variant="unstyled"
+      />
+      <MenuList>
+        <MenuOptionGroup
+          type="checkbox"
+          value={table.getVisibleLeafColumns().map(({ id }) => id)}
+          onChange={(columns: string | string[]) => {
+            table.setColumnVisibility(() =>
+              table.getAllLeafColumns().reduce(
+                (columnVisibility, { id }) => ({
+                  ...columnVisibility,
+                  ...((typeof columns === 'string'
+                    ? [columns]
+                    : columns
+                  ).includes(id)
+                    ? undefined
+                    : { [id]: false }),
+                }),
+                {}
+              )
+            );
+          }}
+        >
           {table
             .getAllLeafColumns()
             .filter(
@@ -52,16 +67,7 @@ const getColumnDefActionMenu = <Datum extends object, TValue = any>({
                 meta?.disableColumnVisibilityToggling !== true
             )
             .map(
-              (
-                {
-                  columnDef: { header },
-                  getIsVisible,
-                  getToggleVisibilityHandler,
-                  id,
-                },
-                index,
-                array
-              ) => {
+              ({ columnDef: { header }, getIsVisible, id }, index, array) => {
                 const visibleColumns = array.reduce(
                   (visibleColumnsCount, column) =>
                     visibleColumnsCount + (column.getIsVisible() ? 1 : 0),
@@ -71,23 +77,20 @@ const getColumnDefActionMenu = <Datum extends object, TValue = any>({
                 const isVisible = getIsVisible();
 
                 return (
-                  <Checkbox
+                  <MenuItemOption
                     key={id}
                     isChecked={isVisible}
                     isDisabled={visibleColumns === 1 && isVisible}
-                    paddingX="md"
-                    paddingY="xs"
-                    size="sm"
-                    onChange={getToggleVisibilityHandler()}
+                    value={id}
                   >
                     {String(header)}
-                  </Checkbox>
+                  </MenuItemOption>
                 );
               }
             )}
-        </PopoverBody>
-      </PopoverContent>
-    </Popover>
+        </MenuOptionGroup>
+      </MenuList>
+    </Menu>
   ),
 
   id: 'actionMenu',
@@ -97,6 +100,7 @@ const getColumnDefActionMenu = <Datum extends object, TValue = any>({
     disableColumnVisibilityToggling: true,
     minimumWidth: true,
     noHeaderCellPaddings: true,
+    sticky: { right: 0 },
   },
 });
 

--- a/src/components/Table/columnDef/getColumnDefMultiRowSelection.tsx
+++ b/src/components/Table/columnDef/getColumnDefMultiRowSelection.tsx
@@ -36,6 +36,7 @@ const getColumnDefMultiRowSelection = <
     disableSorting: true,
     disableColumnVisibilityToggling: true,
     minimumWidth: true,
+    sticky: { left: 0 },
   },
 });
 

--- a/src/components/Table/index.ts
+++ b/src/components/Table/index.ts
@@ -46,3 +46,4 @@ export type {
 } from './types';
 export { default as useTableRenderer } from './useTableRenderer';
 export type { UseTableRendererProps } from './useTableRenderer';
+export { getCellStickyProps } from './utils';

--- a/src/components/Table/theme.ts
+++ b/src/components/Table/theme.ts
@@ -25,7 +25,13 @@ export default defineMultiStyleConfig({
       width: 'full',
     },
 
-    td: cell,
+    td: {
+      ...cell,
+      background: 'white-0',
+      transitionDuration: 'default',
+      transitionProperty: 'background',
+      transitionTimingFunction: 'default',
+    },
 
     th: {
       ...cell,
@@ -50,11 +56,8 @@ export default defineMultiStyleConfig({
       borderBottomColor: 'gray-1',
       borderBottomStyle: 'solid',
       borderBottomWidth: 1,
-      transitionDuration: 'default',
-      transitionProperty: 'background',
-      transitionTimingFunction: 'default',
 
-      _hover: { background: 'blue-10%' },
+      _hover: { td: { background: 'blue-10%' } },
 
       _last: { borderBottom: 'none' },
     },

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -1,3 +1,4 @@
+import type { PositionProps, SystemProps } from '@chakra-ui/react';
 import type { RowData } from '@tanstack/react-table';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -25,6 +26,23 @@ export interface NautobotUIColumnMeta<TData extends RowData, TValue> {
    * for example when the children handle their own pointer events and styles.
    */
   noHeaderCellPaddings?: boolean;
+
+  /**
+   * Make given column sticky, i.e. always visible, even when table is too wide
+   * to fit inside the browser viewport and overflows. Requires at least one of
+   * the position props (`bottom`, `left`, `right` and/or `top`) to be passed
+   * explicitly. Optionally, any other style props can be passed, e.g. `zIndex`.
+   * Can also be `false` to disable column default sticky behavior.
+   */
+  sticky?:
+    | ((
+        | Required<Pick<PositionProps, 'bottom'>>
+        | Required<Pick<PositionProps, 'left'>>
+        | Required<Pick<PositionProps, 'right'>>
+        | Required<Pick<PositionProps, 'top'>>
+      ) &
+        Partial<SystemProps>)
+    | false;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/components/Table/utils.ts
+++ b/src/components/Table/utils.ts
@@ -1,0 +1,125 @@
+import { calc } from '@chakra-ui/react';
+import type { SystemProps } from '@chakra-ui/react';
+import type { useReactTable } from '@tanstack/react-table';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { RefObject } from 'react';
+
+import { getCssVar } from '../../utils';
+
+export const getCellStickyProps = <Datum extends object>(
+  {
+    columnId,
+    isTableScrolledToTheLeft,
+    isTableScrolledToTheRight,
+    table,
+  }: {
+    columnId: string;
+    isTableScrolledToTheLeft: boolean;
+    isTableScrolledToTheRight: boolean;
+    table: ReturnType<typeof useReactTable<Datum>>;
+  },
+  additionalProps?: Partial<SystemProps>
+) => {
+  const allLeafColumns = table.getAllLeafColumns();
+  const column = allLeafColumns.find(({ id }) => id === columnId);
+  const index = column ? allLeafColumns.indexOf(column) : -1;
+
+  const isFirstUserDefinedColumn =
+    index === (table.options.enableMultiRowSelection ? 1 : 0);
+
+  const isSticky =
+    !!column?.columnDef?.meta?.sticky ||
+    (column?.columnDef?.meta?.sticky !== false && isFirstUserDefinedColumn);
+
+  const overlayDirection = allLeafColumns
+    .slice(index)
+    .every(({ columnDef }) => columnDef?.meta?.sticky)
+    ? 'to-l'
+    : 'to-r';
+
+  const isOverlayVisible =
+    overlayDirection === 'to-l'
+      ? !isTableScrolledToTheRight
+      : !isTableScrolledToTheLeft;
+
+  return isSticky
+    ? {
+        position: 'sticky' as const,
+        zIndex: 1,
+        ...(isFirstUserDefinedColumn
+          ? {
+              left: table.options.enableMultiRowSelection
+                ? calc.add(
+                    calc.subtract(getCssVar('space.16').reference, '1px'),
+                    getCssVar('sizes.20').reference,
+                    getCssVar('space.8').reference
+                  )
+                : 0,
+            }
+          : undefined),
+
+        _before: {
+          bgGradient: `linear(${overlayDirection}, #000000, #D9D9D900)`,
+          content: '""',
+          display: 'inline-block',
+          height: 'full',
+          pointerEvents: 'none',
+          position: 'absolute',
+          top: 0,
+          transitionDuration: 'default',
+          transitionProperty: 'opacity, visibility',
+          transitionTimingFunction: 'default',
+          width: 10,
+          [overlayDirection === 'to-r' ? 'right' : 'left']: calc.multiply(
+            getCssVar('sizes.10').reference,
+            -1
+          ),
+          ...(isOverlayVisible
+            ? { opacity: 0.1, visibility: 'visible' }
+            : { opacity: 0, visibility: 'hidden' }),
+        },
+
+        ...column?.columnDef?.meta?.sticky,
+        ...additionalProps,
+      }
+    : undefined;
+};
+
+export const useTableScrollPosition = (ref: RefObject<HTMLDivElement>) => {
+  const node = ref.current;
+
+  const [isTableScrolledToTheLeft, setIsTableScrolledToTheLeft] =
+    useState(true);
+  const [isTableScrolledToTheRight, setIsTableScrolledToTheRight] =
+    useState(true);
+
+  const updateScrollPosition = useCallback(() => {
+    if (ref.current) {
+      const { clientWidth, scrollLeft, scrollWidth } = ref.current;
+
+      setIsTableScrolledToTheLeft(scrollLeft <= 0);
+      setIsTableScrolledToTheRight(scrollWidth <= clientWidth + scrollLeft);
+    }
+  }, [ref, setIsTableScrolledToTheLeft, setIsTableScrolledToTheRight]);
+
+  useEffect(() => {
+    const resizeObserver = new ResizeObserver(() => {
+      updateScrollPosition();
+    });
+
+    if (ref.current) {
+      ref.current.addEventListener('scroll', updateScrollPosition);
+      resizeObserver.observe(ref.current);
+    }
+
+    return () => {
+      node?.removeEventListener('scroll', updateScrollPosition);
+      resizeObserver.disconnect();
+    };
+  }, [node, ref, updateScrollPosition]);
+
+  return useMemo(
+    () => ({ isTableScrolledToTheLeft, isTableScrolledToTheRight }),
+    [isTableScrolledToTheLeft, isTableScrolledToTheRight]
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -230,6 +230,7 @@ export type { SwitchProps } from './Switch';
 export {
   createColumnHelper,
   flexRender,
+  getCellStickyProps,
   getCoreRowModel,
   getFilteredRowModel,
   getPaginationRowModel,

--- a/src/foundations/zIndices.ts
+++ b/src/foundations/zIndices.ts
@@ -1,5 +1,6 @@
 export default {
   1: 1,
+  2: 2,
   docked: 10,
   'docked+1': 11,
   'docked+2': 12,


### PR DESCRIPTION
This PR implements table sticky columns. They are used by default in `TableRenderer` component for the multi row selection column, first user-defined column ("Name" column on the screenshot below) and action menu column.

*Note: this feature works correctly. although doesn't look as good on Firefox, because of missing borders due to a known bug https://bugzilla.mozilla.org/show_bug.cgi?id=1450584*

![image](https://user-images.githubusercontent.com/117445994/236794807-0d639003-4431-4dc4-8e0e-a19d9867555f.png)
