### PR TITLE
Sidebar nav text colors

### DIFF
--- a/src/components/Accordion/theme.ts
+++ b/src/components/Accordion/theme.ts
@@ -112,7 +112,7 @@ export default defineMultiStyleConfig({
       button: {
         ...variant.sidebar.button,
         background: 'navy-0',
-        color: 'gray-4',
+        color: 'gray-1',
         textTransform: 'uppercase',
 
         _focusVisible: {
@@ -142,7 +142,7 @@ export default defineMultiStyleConfig({
       button: {
         ...variant.sidebar.button,
         background: 'navy-1',
-        color: 'white-0',
+        color: 'gray-1',
         fontWeight: 'normal',
         gap: 'xs',
 

--- a/src/components/Sidebar/SidebarButton.tsx
+++ b/src/components/Sidebar/SidebarButton.tsx
@@ -9,14 +9,15 @@ export interface SidebarButtonProps extends ButtonProps {
   isFirst?: boolean;
   isLast?: boolean;
   treeEdgeProps?: TreeEdgeProps;
+  active?: boolean;
 }
 
 const SidebarButton = forwardRef<SidebarButtonProps, 'button'>(
-  ({ children, isFirst, isLast, level, treeEdgeProps, ...rest }, ref) => (
+  ({ active = false, children, isFirst, isLast, level, treeEdgeProps, ...rest }, ref) => (
     <Button
       ref={ref}
       _disabled={{ color: 'gray-2', pointerEvents: 'none' }}
-      color="gray-1"
+      color={active ? 'orange-0' : 'gray-1'}
       gap="xs"
       justifyContent="flex-start"
       paddingX="md"

--- a/src/components/Sidebar/SidebarButton.tsx
+++ b/src/components/Sidebar/SidebarButton.tsx
@@ -16,7 +16,7 @@ const SidebarButton = forwardRef<SidebarButtonProps, 'button'>(
     <Button
       ref={ref}
       _disabled={{ color: 'gray-2', pointerEvents: 'none' }}
-      color="white-0"
+      color="gray-1"
       gap="xs"
       justifyContent="flex-start"
       paddingX="md"


### PR DESCRIPTION
- Updated text color for sidebar `Accordion` buttons to gray-1 
- Updated `SidebarButton` components to default to gray-1 and become orange-0 when active using active prop