### PR TITLE
feature: restrict table action header menu list to its container boundaries

### DIFF
--- a/src/components/Menu/MenuList.tsx
+++ b/src/components/Menu/MenuList.tsx
@@ -1,0 +1,90 @@
+import {
+  forwardRef,
+  MenuList as ChakraMenuList,
+  useMenuContext,
+} from '@chakra-ui/react';
+import type { MenuListProps as ChakraMenuListProps } from '@chakra-ui/react';
+import React, { useEffect, useRef, useState } from 'react';
+
+export interface MenuListProps extends ChakraMenuListProps {
+  restrictToViewport?: boolean;
+}
+
+const MenuList = forwardRef<MenuListProps, 'div'>(
+  ({ restrictToViewport, ...rest }, ref) => {
+    const internalRef = useRef<HTMLDivElement>(null);
+
+    const menuListRef = ref ?? internalRef;
+
+    const { isOpen } = useMenuContext();
+
+    const [style, setStyle] = useState<
+      | { maxHeight?: number | undefined; overflowY?: 'auto' | undefined }
+      | undefined
+    >();
+
+    useEffect(() => {
+      const isMenuListRefValid =
+        typeof menuListRef === 'object' && !!menuListRef.current;
+
+      if (isMenuListRefValid && isOpen && restrictToViewport) {
+        const menuList: HTMLDivElement = menuListRef.current;
+        const nearestScrollableAncestorElement = (() => {
+          let ancestorElement: HTMLElement = menuList;
+          let isScrollable = false;
+
+          while (!isScrollable) {
+            // Return `ancestorElement` if it is already the top-level element.
+            if (!ancestorElement.parentElement) {
+              return ancestorElement;
+            }
+
+            ancestorElement = ancestorElement.parentElement;
+            isScrollable =
+              ancestorElement.clientHeight < ancestorElement.scrollHeight &&
+              ['auto', 'scroll'].includes(
+                window.getComputedStyle(ancestorElement).overflowY
+              );
+          }
+
+          return ancestorElement;
+        })();
+
+        const { height, y } = menuList.getBoundingClientRect();
+        const { y: nearestScrollableAncestorElementY } =
+          nearestScrollableAncestorElement.getBoundingClientRect();
+        const { scrollHeight, scrollTop } = nearestScrollableAncestorElement;
+
+        const maxHeight =
+          nearestScrollableAncestorElementY + scrollHeight - scrollTop - y;
+
+        setStyle(
+          height > maxHeight ? { maxHeight, overflowY: 'auto' } : undefined
+        );
+      } else {
+        setStyle(undefined);
+      }
+    }, [isOpen, restrictToViewport]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    useEffect(() => {
+      if (style?.maxHeight !== undefined) {
+        setTimeout(() =>
+          setTimeout(() => {
+            const isMenuListRefValid =
+              typeof menuListRef === 'object' && !!menuListRef.current;
+
+            if (isMenuListRefValid) {
+              menuListRef.current.scrollTop = 0;
+            }
+          })
+        );
+      }
+    }, [style]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    return <ChakraMenuList ref={menuListRef} {...style} {...rest} />;
+  }
+);
+
+MenuList.displayName = 'MenuList';
+
+export default MenuList;

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -2,7 +2,6 @@ export {
   MenuButton,
   MenuDivider,
   MenuGroup,
-  MenuList,
   MenuOptionGroup,
   useMenuContext,
 } from '@chakra-ui/react';
@@ -10,7 +9,6 @@ export type {
   MenuButtonProps,
   MenuDividerProps,
   MenuGroupProps,
-  MenuListProps,
   MenuOptionGroupProps,
   UseMenuReturn,
 } from '@chakra-ui/react';
@@ -21,3 +19,5 @@ export { default as MenuItem } from './MenuItem';
 export type { MenuItemProps } from './MenuItem';
 export { default as MenuItemOption } from './MenuItemOption';
 export type { MenuItemOptionProps } from './MenuItemOption';
+export { default as MenuList } from './MenuList';
+export type { MenuListProps } from './MenuList';

--- a/src/components/Table/columnDef/getColumnDefActionMenu.tsx
+++ b/src/components/Table/columnDef/getColumnDefActionMenu.tsx
@@ -24,7 +24,7 @@ const getColumnDefActionMenu = <Datum extends object, TValue = any>({
     ActionMenu ? <ActionMenu cellContext={cellContext} /> : null,
 
   header: ({ table }: HeaderContext<Datum, TValue>) => (
-    <Menu closeOnSelect={false} placement="bottom-end">
+    <Menu closeOnSelect={false} placement="bottom-end" strategy="fixed">
       <MenuButton
         _active={{ background: 'blue-10%' }}
         _focusVisible={{ background: 'blue-10%' }}
@@ -39,7 +39,7 @@ const getColumnDefActionMenu = <Datum extends object, TValue = any>({
         paddingY={calc.subtract(getCssVar('space.12').reference, '1px')}
         variant="unstyled"
       />
-      <MenuList>
+      <MenuList restrictToViewport>
         <MenuOptionGroup
           type="checkbox"
           value={table.getVisibleLeafColumns().map(({ id }) => id)}


### PR DESCRIPTION
This PR restricts table action header menu list to its container boundaries, so it does not overflow outside of browser viewport. In theory this should be done automatically by Popper, but in some cases the menu list is so long, that it doesn't fit the screen in any direction and requires additional logic and styling.

As presented on the screenshot below, the menu list becomes scrollable if it does not fit the screen:

![image](https://github.com/nautobot/nautobot-ui/assets/117445994/2658d9af-611b-4e99-8739-bc8252932266)
