### PR TITLE
fix: missing ref in breadcrumbs stories

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -15,8 +15,8 @@ export default Story;
 const MockedReactRouterLink = forwardRef<
   HTMLAnchorElement,
   HTMLProps<HTMLAnchorElement> & { to: string }
->(({ children, to, ...rest }) => (
-  <a href={to} {...rest} onClick={(event) => event.preventDefault()}>
+>(({ children, to, ...rest }, ref) => (
+  <a ref={ref} href={to} {...rest} onClick={(event) => event.preventDefault()}>
     {children}
   </a>
 ));


### PR DESCRIPTION
This PR fixes the following error caused by missing `ref` in `Breadcrumbs` component stories:

![image](https://github.com/nautobot/nautobot-ui/assets/117445994/1fc8e2fb-08bd-4fef-8495-05a1836ed6bf)
